### PR TITLE
Updated requirements to include Flask-babel

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,3 @@
 # cloud foundry
 Flask==0.10.1
-whitenoise==1.0.6
-dj-database-url==0.3.0
-waitress==0.8.9
+Flask-Babel==0.9


### PR DESCRIPTION
This was forgotten the first time around because it was not
realized that there was a separate requirements.txt file for the web
app vs the whole app.