### PR TITLE
177 fix extra column error

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -196,7 +196,8 @@ def validate_headers(dataframe, correct_headers):
     except:
         return False
 
-    return sorted(headers) == sorted(correct_headers)
+    #ignore extra columns in the uploaded files
+    return set(correct_headers).issubset(set(headers))
 
 def check_file(file, dataframe, valid_headers, template_name):
     message = ''
@@ -217,9 +218,9 @@ def check_file(file, dataframe, valid_headers, template_name):
 
     return None
 
-def validate_file(file, template_name):
+def validate_file(dataframe, template_name):
     validator = ValidatorSingle(
-            file,
+            dataframe,
             template_name,
             RULES_DIR)
 
@@ -257,6 +258,7 @@ def hello_world():
         for name in VALIDATION.keys():
             try:
                 dataframe = pd.read_csv(files[name].stream)
+                dataframe = dataframe.fillna('')
                 files[name].seek(0)
             except:
                 dataframe = pd.DataFrame()
@@ -264,7 +266,7 @@ def hello_world():
             if error:
                 invalid_files.append(error)
             else:
-                error = validate_file(files[name], name)
+                error = validate_file(dataframe, name)
                 if error:
                     invalid_files.append(file_info(
                        files[name],

--- a/app/app.py
+++ b/app/app.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from functools import wraps
+import pandas as pd
 
 from flask import Flask, request, Response, url_for, render_template
 from flask.ext.babel import Babel
@@ -189,17 +190,15 @@ def allowed_file(filename):
     return '.' in filename and \
            filename.rsplit('.', 1)[1] in ALLOWED_EXTENSIONS
 
-def validate_headers(csv_file, correct_headers):
-    reader = csv.reader(csv_file)
+def validate_headers(dataframe, correct_headers):
     try:
-        headers = reader.next()
-    except StopIteration:
+        headers = list(dataframe.columns.values)
+    except:
         return False
 
-    csv_file.seek(0)
     return sorted(headers) == sorted(correct_headers)
 
-def check_file(file, valid_headers, template_name):
+def check_file(file, dataframe, valid_headers, template_name):
     message = ''
     detail = ''
     if not file:
@@ -210,8 +209,8 @@ def check_file(file, valid_headers, template_name):
         message = 'File is of incorrect type'
         detail = 'The uploaded file must be a .csv file'
         return file_info(file, template_name, [], message, err_detail=detail)
-    if not validate_headers(file, valid_headers):
-        message = 'File spreadsheet headers dont\'t match with the data act \
+    if not validate_headers(dataframe, valid_headers):
+        message = 'File spreadsheet headers don\'t match with the data act \
             template'
         detail = 'Ensure csv file has the same headers as the templates'
         return file_info(file, template_name, [], message, err_detail=detail)
@@ -253,9 +252,15 @@ def hello_world():
     if request.method == 'POST':
         correct_files = []
         files = request.files
+        dataframes = {}
         invalid_files = []
         for name in VALIDATION.keys():
-            error = check_file(files[name], VALIDATION[name], name)
+            try:
+                dataframe = pd.read_csv(files[name].stream)
+                files[name].seek(0)
+            except:
+                dataframe = pd.DataFrame()
+            error = check_file(files[name], dataframe, VALIDATION[name], name)
             if error:
                 invalid_files.append(error)
             else:

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -2,7 +2,7 @@
 #all applications use these settings and services
 applications:
 - name: data-act-pilot
-  memory: 512M
+  memory: 1024M
   command: "python app.py"
 #  instances: 1
   #path: ./app

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 # cloud foundry
 Flask==0.10.1
 Flask-Babel==0.9
+pandas

--- a/app/validator/validator.py
+++ b/app/validator/validator.py
@@ -65,7 +65,7 @@ class Validator(object):
         Expects:
             dataframe: dataframe of the agency-submitted CSV
         Outputs:
-            A list of dicts produced by csv.DictReader'''
+            A list of dicts'''
 
         if dataframe is None:
             return ''
@@ -158,6 +158,7 @@ class Validator(object):
                                                     field,
                                                     length=rule['field_length'])
                         results.append(error)
+                    if not self.check_unique(rule['unique'], )
             else:
                 #for the prototype, ignore extra columns on submitted csvs
                 pass

--- a/app/validator/validator.py
+++ b/app/validator/validator.py
@@ -59,17 +59,17 @@ class Validator(object):
 
         self.results = self.validate_submission()
 
-    def load_data(self, filepath):
+    def load_data(self, dataframe):
         '''Loads data from submitted agency CSV
 
         Expects:
-            filepath: path to the CSV to be loaded
+            dataframe: dataframe of the agency-submitted CSV
         Outputs:
             A list of dicts produced by csv.DictReader'''
 
-        if filepath is None:
+        if dataframe is None:
             return ''
-        return [row for row in csv.DictReader(filepath)]
+        return dataframe.to_dict('records')
 
     def load_simple_rules(self, rules_file):
         base = os.path.dirname(__file__)
@@ -83,6 +83,8 @@ class Validator(object):
     def check_required(self, required, value):
         if not eval(required) or value:
                 return True
+        elif value == 0:
+            return True
 
     def check_data_type(self, data_type, value):
         try:
@@ -92,7 +94,7 @@ class Validator(object):
             return False
 
     def check_length(self, length, value):
-        if len(value) <= length:
+        if len(str(value)) <= length:
             return True
 
     def check_unique(self, value):
@@ -116,7 +118,7 @@ class Validator(object):
         key = ''
         for field in TAS_KEY_IDENTIFIERS:
             if data[field]:
-                key += data[field] + '-'
+                key += str(data[field]) + '-'
 
         return key[:-1]
 
@@ -157,7 +159,8 @@ class Validator(object):
                                                     length=rule['field_length'])
                         results.append(error)
             else:
-                raise TypeError('field ' + field + 'not recongized')
+                #for the prototype, ignore extra columns on submitted csvs
+                pass
         return results
 
     def validate_file(self, filename, data, rules):
@@ -206,10 +209,10 @@ class Validator(object):
 
 class ValidatorSingle(Validator):
     def __init__(self,
-               file_obj,
+               file_dataframe,
                file_template,
                rules_dir):
-        self.file_data = self.load_data(file_obj)
+        self.file_data = self.load_data(file_dataframe)
         self.file_template = file_template
         self.rules = self.load_simple_rules(rules_dir +
                 file_template[:-4] + '_rules' + file_template[-4:])


### PR DESCRIPTION
This fixes #177 and introduces two things:

1. Addresses some of the brittleness around csvs with different newline formats. Normally I'd just open the .csv in universal-newline mode, but in this case, that would require a hack around the Flask internals that stream the file. Instead I used pandas, which I eventually was going to incorporate anyway to reduce some of the column name hardcoding. This means we'll have to figure out why the Pandas install doesn't work on the Vagrant box.

2. Ignores extra columns in the validations. For this prototype, agencies may be submitting files that contain the larger universe of required data elements, whereas the scope of this pilot was smaller (just the original 83 element). To make this easier, we're validating the elements in our scope and just ignoring anything else on the .csvs.