### PR TITLE
fix validation rule for AwardingOfficeName

### DIFF
--- a/app/validator/rules/award_rules.csv
+++ b/app/validator/rules/award_rules.csv
@@ -12,7 +12,7 @@ RecipientLegalEntityAddressStreet2,False,str,150,False
 RecipientLegalEntityCityName,False,str,40,False
 RecipientLegalEntityStateCode,False,str,2,False
 RecipientLegalEntityZip,False,int,5,False
-AwardingOfficeName,False,int,4,False
+AwardingOfficeName,False,str,25,False
 RecordType,False,int,1,True
 AssistanceType,False,int,2,True
 PlaceOfPerfCity,False,str,40,True


### PR DESCRIPTION
Fix #194. In the validation rules .csv for the awards file, change the data type from AwardingOfficeName from into to str. The string length (25) comes from the most current version of the data elements guidance.