### PR TITLE
Create .about.yml

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,0 +1,21 @@
+---
+project: DATA Act
+name: dataact
+github:
+- fedspendingtransparency/fedspendingtransparency.github.io
+description: Consulting engagement to advise on the federal spending data standards and corresponding pilot project mandated by the DATA Act.
+partners:
+- U.S. Department of Treasury
+impact: The federal agencies, state and local governments, transparency advocacy organizations, non-profits, academic researchers, and individuals who use federal spending data. All federal agencies can benefit from the pilot software and lessons learned as they prepare to comply with the DATA Act.
+stage: alpha
+milestones:
+- 'January 2015: 18F began work on project'
+contact:
+- kaitlin.devine@gsa.gov
+stack: JavaScript, Jekyll
+team: kaitlin, becky, kate, micahsaul
+licenses:
+  fedspendingtransparency: Public Domain (CC0)
+links:
+  - https://fedspendingtransparency.github.io/
+status:


### PR DESCRIPTION
As we scale out the [about.yml](https://github.com/18f/about_yml) standard on projects, we need to relocates the yml file for this project from [here](https://github.com/18F/data-private/blob/master/projects/dataact.yml) to the primary project repo.